### PR TITLE
Fix for #1911: don't assume SQLite in setup.

### DIFF
--- a/ka-lite/kalite/__init__.py
+++ b/ka-lite/kalite/__init__.py
@@ -1,3 +1,10 @@
+import os
+
+from django.conf import settings
+
+from version import *
+
+
 # suppress warnings here.
 try:
     import warnings
@@ -5,4 +12,18 @@ try:
 except:
     pass
 
-from version import *
+
+def is_installed():
+    """Returns True if KA Lite is installed."""
+
+    if "sqlite" in settings.DATABASES["default"]["ENGINE"]:
+        return os.path.exists(settings.DATABASES["default"]["NAME"])  # this is the db filepath for SQLite
+    else:
+        # TODO(bcipolli): use django raw connection to test; something like:
+        # from django.db import connection
+        # try:
+        #     connection.introspection.table_names()
+        #     return True
+        # except:
+        #     return False
+        return True


### PR DESCRIPTION
In migrating our ansible scripts to use this setup command (see https://github.com/fle-internal/ansible-playbooks/pull/17), it became clear that our setup script assumes a SQLite back-end.

One core goal for KA Lite is to make the product database engine-agnostic.  This PR does that! :)

Testing:
- Tested sqlite clean and upgrade installs.  Both work as previously.
