### PR TITLE
Fix for #117: use Khan Academy redirect URL to get latest videos.

### DIFF
--- a/centralserver/i18n/__init__.py
+++ b/centralserver/i18n/__init__.py
@@ -135,13 +135,15 @@ def get_supported_languages():
 
 DUBBED_VIDEO_MAP_RAW = None
 DUBBED_VIDEO_MAP = None
-def get_dubbed_video_map(lang_code=None, force=False):
+def get_dubbed_video_map(lang_code=None, reload=None, force=False):
     """
     Stores a key per language.  Value is a dictionary between video_id and (dubbed) youtube_id
     """
     global DUBBED_VIDEO_MAP, DUBBED_VIDEO_MAP_RAW, DUBBED_VIDEOS_MAPPING_FILEPATH
 
-    if DUBBED_VIDEO_MAP is None or force:
+    reload = (reload is None and force) or reload  # default of reload is force
+
+    if DUBBED_VIDEO_MAP is None or reload:
         try:
             if not os.path.exists(DUBBED_VIDEOS_MAPPING_FILEPATH) or force:
                 try:


### PR DESCRIPTION
Needed to capture the redirect for ourselves, so we could append `output=csv`.  Also added code to detail what changes have been made.

Note that the bugs in the output (reversed `added` and `removed`; spacing is weird) have been fixed.

![screen shot 2014-04-16 at 8 22 59 am](https://cloud.githubusercontent.com/assets/4072455/2721489/c706af7a-c57b-11e3-9765-92c9f4150c1f.png)

Goal is to get this in with a central server change ASAP, both because we have hundreds of dubbed videos we're not making available to our users, and because we have a specific partner who is asking for these to be updated.

@aronasorman Time for a looksie?
