### PR TITLE
Paginate sync sessions.

### DIFF
--- a/centralserver/deployment/views.py
+++ b/centralserver/deployment/views.py
@@ -9,7 +9,7 @@ from django.db.models import Sum, Max, Count, F, Q, Min
 from django.utils.translation import ugettext as _
 
 from centralserver.central.models import Organization
-from fle_utils.django_utils.paginate import pages_to_show, paginate_data
+from fle_utils.django_utils.paginate import paginate_data
 from kalite.facility.models import Facility
 from kalite.shared.decorators import require_authorized_admin
 from securesync.models import DeviceZone

--- a/ka-lite/kalite/control_panel/templates/control_panel/device_management.html
+++ b/ka-lite/kalite/control_panel/templates/control_panel/device_management.html
@@ -1,6 +1,7 @@
 {% extends "control_panel/base.html" %}
 {% load i18n %}
 {% load staticfiles %}
+{% load my_filters %}
 
 {% block title %}{% blocktrans with device_name=device.name %}{{ device_name }} Device Syncing History{% endblocktrans %}{{ block.super }}{% endblock title %}
 
@@ -43,9 +44,9 @@
             {% else %}
                 <!---Remote system status -->
                 <dt>{% trans "Version" %}:</dt>
-                <dd>{{ shown_sessions.0.client_version }}</dd>
+                <dd>{{ device_version }}</dd>
                 <dt>{% trans "Operating System" %}:</dt>
-                <dd>{{ shown_sessions.0.client_os }}</dd>
+                <dd>{{ device_os }}</dd>
             {% endif %}
             </dl>
         </div>
@@ -55,14 +56,29 @@
                 <h2>{% trans "Sync Sessions" %}</h2>
             </div>
 
-            {% if not shown_sessions %}
+            {% if not session_pages %}
                 <p class="registered-only">{% trans "This device has never synced with the central server." %}</p>
                 <p class="not-registered-only">{% trans "This device is not registered, and so cannot sync data with the central server." %}</p>
             {% else %}
-                {% with shown_sessions|length as shown_count %}
-                {# Translators: shown_count and total_sessions are integer variables; do not translate them! #}
-                <span>({% blocktrans %}showing {{ shown_count }} of {{ total_sessions }}{% endblocktrans %})</span>
-                {% endwith %}
+                {% if session_pages.num_listed_pages > 1 %}
+                <div class="pagination">
+                        <a title="{% trans 'Browse to the previous page of sync sessions.' %}" {% if session_pages.has_previous %}href="{{ page_urls.prev_page }}"{% endif %}>&lt&lt</a>
+                        {% for listed_page in session_pages.listed_pages %}
+                            {% if listed_page == -1 %}
+                                <span class="disabled">&hellip;</span>
+                            {% elif listed_page == session_pages.number %}
+                                <span class="current">
+                                   {{ session_pages.number }}
+                                </span>
+                            {% else %}
+                                <a title="{% blocktrans %}Browse to page # {{ listed_page }} of sessions.{% endblocktrans %}" href="{{ page_urls|get_item:listed_page }}">{{ listed_page }}</a>
+                            {% endif %}
+                        {% endfor %}
+                        <a title="{% trans 'Browse to the next page of sessions.' %}" {% if session_pages.has_next %}href="{{ page_urls.next_page }}"{% endif %}>&gt&gt</a>
+                </div>
+                <div class="clear"></div>
+                {% endif %}
+
                 <table class="simple-table">
                     <tr>
                         <th width="250px">{% trans "Sync Date" %}</th>
@@ -71,7 +87,7 @@
                         <th width="200px">{% trans "# Models Downloaded" %}</th>
                         <th width="200px">{% trans "# Errors" %}</th>
                     </tr>
-                    {% for sync_session in shown_sessions %}
+                    {% for sync_session in session_pages %}
                         <tr>
                             <td>{{ sync_session.timestamp }}</td>
                             <td>{{ sync_session.ip }}</td>

--- a/ka-lite/kalite/control_panel/views.py
+++ b/ka-lite/kalite/control_panel/views.py
@@ -20,7 +20,7 @@ from django.utils.translation import ugettext as _
 
 from .forms import ZoneForm, UploadFileForm, DateRangeForm
 from fle_utils.internet import CsvResponse, render_to_csv
-from fle_utils.django_utils.paginate import paginate_data, pages_to_show
+from fle_utils.django_utils.paginate import paginate_data
 from kalite.coachreports.views import student_view_context
 from kalite.facility import get_users_from_group
 from kalite.facility.decorators import facility_required
@@ -149,17 +149,26 @@ def zone_management(request, zone_id="None"):
 
 @require_authorized_admin
 @render_to("control_panel/device_management.html")
-def device_management(request, device_id, zone_id=None, n_sessions=10):
+def device_management(request, device_id, zone_id=None, per_page=None, cur_page=None):
     context = control_panel_context(request, zone_id=zone_id, device_id=device_id)
+
+    #Get pagination details
+    cur_page = cur_page or request.REQUEST.get("cur_page", "1")
+    per_page = per_page or request.REQUEST.get("per_page", "10")
 
     # Retrieve sync sessions
     all_sessions = SyncSession.objects.filter(client_device=context["device"])
     total_sessions = all_sessions.count()
-    shown_sessions = list(all_sessions.order_by("-timestamp")[:n_sessions])
+    shown_sessions = list(all_sessions.order_by("-timestamp").values("timestamp", "ip", "models_uploaded", "models_downloaded", "errors"))
+
+    session_pages, page_urls = paginate_data(request, shown_sessions, page=cur_page, per_page=per_page)
 
     context.update({
-        "shown_sessions": shown_sessions,
+        "session_pages": session_pages,
+        "page_urls": page_urls,
         "total_sessions": total_sessions,
+        "device_version": total_sessions and all_sessions[0].client_version or None,
+        "device_os": total_sessions and all_sessions[0].client_os or None,
         "is_own_device": not settings.CENTRAL_SERVER and device_id == Device.get_own_device().id,
     })
 


### PR DESCRIPTION
This will help debug @mikewray 's syncing issues; currently we can't see the necessary data in the `device_management` view because there is no pagination of sync sessions.

Now, default is 10 sync sessions per page, and we get pagination.

@aronasorman This is a straightforward feature request, and an answer for @mikewray depends on this, so I'd like to push this through today if possible.

![image](https://cloud.githubusercontent.com/assets/4072455/2830313/983beff2-cfad-11e3-8006-bcaa3cff432c.png)
