### PR TITLE
Hotfix: Import sprintf.min.js in central base.html

### DIFF
--- a/centralserver/central/templates/central/base.html
+++ b/centralserver/central/templates/central/base.html
@@ -43,6 +43,7 @@
           <script type="text/javascript" src="{% static 'js/backbone-min.js' %}"></script>
           <script type="text/javascript" src="{% static 'js/bootstrap.min.js' %}"></script>
           <script type="text/javascript" src='{% static "js/bootstrap-timepicker.min.js" %}'></script>
+          <script type="text/javascript" src="{% static 'js/sprintf.min.js' %}"></script>
 
           <script type="text/javascript" src="{% static 'js/i18n/en.js' %}"></script>
           <script type="text/javascript" src="{% static 'js/khan-lite.js' %}"></script>


### PR DESCRIPTION
Resolve https://github.com/learningequality/ka-lite/issues/2013

Currently D3 based coach reports are non-functional on the central server. This fixes that by importing the widespread dependency module, sprintf, into the base template of the central server.

Fixes issue, and I would think is low risk.

@jamalex or @aronasorman - can you review and push to the server if it is satisfactory? @mikewray has suggested this is a blocker to demoing for deployments.
