### PR TITLE
Fix for #218-Some strings aren't being pulled by makemessages when update_pot is run

### DIFF
--- a/centralserver/i18n/management/commands/update_pot.py
+++ b/centralserver/i18n/management/commands/update_pot.py
@@ -94,8 +94,7 @@ def run_makemessages(verbosity=0):
         ensure_dir("locale")
         call_command("makemessages", locale="en", ignore_patterns=ignore_patterns, no_obsolete=True, domain="django")
         call_command("makemessages", locale="en", ignore_patterns=ignore_patterns, no_obsolete=True, domain="djangojs")
-
-        return glob.glob(os.path.join(settings.KALITE_PATH, "locale", "en", "LC_MESSAGES", "*.po"))
+        return glob.glob(os.path.join(''.join(settings.LOCALE_PATHS), "en", "LC_MESSAGES", "*.po"))
 
 
 def insert_translator_comments(po_filepaths):


### PR DESCRIPTION
Hi @aronasorman - this fixes #218 which is related to https://github.com/learningequality/ka-lite/issues/2755

What I did is to run at the root of the repo to include the `ka-lite-submodule` for the `update_pot` command which calls the `makemessages` command to generate the `*.po` files.

The effect however is that the location of the generated `*.po` files is now at `/locale/en/LC_MESSAGES/`.

I also added `"*/i18n/build/*", "*/media/language_packs/*"` to the list of `ignore_patterns`.

As of today `django.po` has about 133KB and the `djangojs.po` has 76KB file size.  The `django.po` now includes the "Learn" string at the navigation link.

I haven't tried running with the `update_pot -u` switch yet - thought I might ping you with this PR first. :smile_cat: 
