### PR TITLE
Add test for redirect loop issue in distributed server

### DIFF
--- a/centralserver/central/tests/utils/distributed_server_factory.py
+++ b/centralserver/central/tests/utils/distributed_server_factory.py
@@ -209,7 +209,7 @@ OWN_DEVICE_PRIVATE_KEY = %r
 
         return self.runcode(code)["count"]
 
-    def register(self, username, password, zone_id):
+    def register(self, username, password, zone_id, noerr=False):
         '''
         Registers the distributed server to the zone id, which the user
         given by the username and password is a part of. Returns the
@@ -222,7 +222,7 @@ OWN_DEVICE_PRIVATE_KEY = %r
             zone=zone_id,
             output_to_stdout=False,
             output_to_stderr=False,
-        ).wait()
+        ).wait(noerr)
 
         return result
 

--- a/centralserver/central/tests/utils/distributed_server_factory.py
+++ b/centralserver/central/tests/utils/distributed_server_factory.py
@@ -127,7 +127,7 @@ OWN_DEVICE_PRIVATE_KEY = %r
         returncode = self.running_process.returncode
         self.running_process = None  # so we can run other commands
 
-        if noerr or returncode != 0:
+        if not noerr and returncode != 0:
             errmsgtemplate = "command returned non-zero errcode: stderr is %s"
             print stderr
             raise subprocess.CalledProcessError(returncode,
@@ -243,7 +243,7 @@ OWN_DEVICE_PRIVATE_KEY = %r
 
         return json.loads(stdout)
 
-    def runcode(self, code):
+    def runcode(self, code, noerr=False):
         '''
         Runs a block of code and returns a dictionary with the serializable
         portions of the resulting local namespace.
@@ -257,8 +257,11 @@ OWN_DEVICE_PRIVATE_KEY = %r
             code,
             output_to_stdout=False,
             output_to_stderr=False,
-        ).wait()
+        ).wait(noerr)
 
+        # json.loads will return an error when given an empty string, so send it an empty JSON object string
+        if not stdout:
+            stdout = "{}"
         return json.loads(stdout)
 
     def validate(self):


### PR DESCRIPTION
Add a test for issue 2872 in learningequality/ka-lite.
It's possible that registration can be interrupted and put the database
in a bad state, so we simulate a bad registration by judiciously deleting
rows. The server should recover from such a bad registration gracefully.
Also had to add some keyword arg passing to suppress a CalledProcessError
exception being raised by DistributedServer.wait (which was apparently
another bug).