### PR TITLE
Optimize and fix update_language_packs

### DIFF
--- a/centralserver/i18n/management/commands/scrape_exercises.py
+++ b/centralserver/i18n/management/commands/scrape_exercises.py
@@ -76,7 +76,7 @@ class Command(BaseCommand):
             # Get list of exercises
             exercise_ids = options["exercise_ids"].split(",") if options["exercise_ids"] else None
             exercise_ids = exercise_ids or ([ex["id"] for ex in get_topic_exercises(topic_id=options["topic_id"])] if options["topic_id"] else None)
-            exercise_ids = exercise_ids or get_node_cache("Exercise").keys()
+            exercise_ids = exercise_ids or [k for (k, e) in get_node_cache("Exercise").iteritems() if not e.get('uses_assessment_items', False)]
 
             # Download the exercises
             pool = ThreadPool(processes=5)

--- a/centralserver/i18n/management/commands/scrape_exercises.py
+++ b/centralserver/i18n/management/commands/scrape_exercises.py
@@ -12,6 +12,7 @@ import glob
 import os
 import requests
 import shutil
+from multiprocessing.dummy import Pool as ThreadPool
 from optparse import make_option
 
 from django.conf import settings; logging = settings.LOG
@@ -78,8 +79,9 @@ class Command(BaseCommand):
             exercise_ids = exercise_ids or get_node_cache("Exercise").keys()
 
             # Download the exercises
-            for exercise_id in exercise_ids:
-                scrape_exercise(exercise_id=exercise_id, lang_code=lang_code, force=options["force"])
+            pool = ThreadPool(processes=5)
+            f = lambda ex_id: scrape_exercise(exercise_id=ex_id, lang_code=lang_code, force=options["force"])
+            pool.map(f, exercise_ids)
 
         logging.info("Process complete.")
 

--- a/centralserver/i18n/management/commands/update_language_packs.py
+++ b/centralserver/i18n/management/commands/update_language_packs.py
@@ -565,13 +565,14 @@ def convert_aws_urls_to_localhost_urls(poentry):
     """ Strings grabbed from KA may contain urls pointing to files hosted on aws.
     We rehost those files locally, but the strings need to be updated. This function
     just converts aws urls to localholst urls in both the original string and the translated string.
-    
+
     :param: poentry - A polib.POEntry instance
     """
     poentry.msgid = convert_urls(poentry.msgid)
     poentry.msgstr = convert_urls(poentry.msgstr)
     poentry.msgid_plural = convert_urls(poentry.msgid_plural)
-    poentry.msgstr_plural = convert_urls(poentry.msgstr_plural)
+    # so poentry.msgstr_plural can be a dict, so we loop over the values and convert those
+    poentry.msgstr_plural = {k: convert_urls(v) for (k, v) in poentry.msgstr_plural.iteritems()}
     return poentry
 
 

--- a/centralserver/i18n/tests/translation_tests.py
+++ b/centralserver/i18n/tests/translation_tests.py
@@ -21,16 +21,14 @@ class UrlConversionTestCase(TestCase):
     def test_poentry_urls_converted(self):
         """ poentry urls should be converted from aws urls to localhost urls """
         poentry = MagicMock(autospec=polib.POEntry)
-        poentry.msgid = poentry.msgid_plural = "I love https://something.aws.org/cat_picture.jpg"
-        poentry.msgstr = poentry.msgstr_plural = "Ich liebe https://something.aws.org/cat_picture.jpg"
-        
+        poentry.msgid = "I love https://something.aws.org/cat_picture.jpg"
+        poentry.msgstr = "Ich liebe https://something.aws.org/cat_picture.jpg"
+
         poentry = convert_aws_urls_to_localhost_urls(poentry)
 
         converted_url = "/content/khan/cat_picture.jpg"
         self.assertIn(converted_url, poentry.msgid)
-        self.assertIn(converted_url, poentry.msgid_plural)
         self.assertIn(converted_url, poentry.msgstr)
-        self.assertIn(converted_url, poentry.msgstr_plural)
 
 class TranslationCommentTestCase(LiveServerTestCase):
     """


### PR DESCRIPTION
Does a couple of things:
- Parallelize the downloading of exercise files
- Don't download exercise files if they're perseus exercises
- Properly translate `poentry.msgstr_plural`.