### PR TITLE
Do not swamp Postmark API key.

### DIFF
--- a/centralserver/settings.py
+++ b/centralserver/settings.py
@@ -196,7 +196,7 @@ AUTH_PROFILE_MODULE = "central.UserProfile"
 TASTYPIE_DEFAULT_FORMATS = ['json']
 API_LIMIT_PER_PAGE = 0
 
-POSTMARK_API_KEY = ""
+POSTMARK_API_KEY = getattr(local_settings, "POSTMARK_API_KEY", "")
 
 # Whether this was built by a build server; it's not.
 BUILT = getattr(local_settings, "BUILT", False)

--- a/centralserver/testing/settings.py
+++ b/centralserver/testing/settings.py
@@ -2,6 +2,7 @@ import os
 
 try:
     import local_settings
+    from local_settings import *
 except ImportError:
     local_settings = object()
 


### PR DESCRIPTION
This was causing the user registration issues on the staging server.