### PR TITLE
Fix UrlConversionTestCase

### DIFF
--- a/centralserver/central/tests/url_conversion_test.py
+++ b/centralserver/central/tests/url_conversion_test.py
@@ -1,0 +1,24 @@
+"""
+"""
+import polib
+
+from mock import MagicMock
+from django.test import TestCase
+
+from centralserver.i18n.management.commands.update_language_packs import convert_aws_urls_to_localhost_urls
+
+class UrlConversionTestCase(TestCase):
+
+    def test_poentry_urls_converted(self):
+        """ poentry urls should be converted from aws urls to localhost urls """
+        poentry = MagicMock(autospec=polib.POEntry)
+        poentry.msgid = "I love https://something.aws.org/cat_picture.jpg"
+        poentry.msgstr = "Ich liebe https://something.aws.org/cat_picture.jpg"
+        poentry.msgid_plural = ""
+        poentry.msgstr_plural = dict("")
+
+        poentry = convert_aws_urls_to_localhost_urls(poentry)
+
+        converted_url = "/content/khan/cat_picture.jpg"
+        self.assertIn(converted_url, poentry.msgid)
+        self.assertIn(converted_url, poentry.msgstr)

--- a/centralserver/i18n/tests/translation_tests.py
+++ b/centralserver/i18n/tests/translation_tests.py
@@ -5,30 +5,12 @@ import os
 import polib
 import sys
 
-from mock import MagicMock
-
 from django.conf import settings
 from django.core.management import call_command
-from django.test import LiveServerTestCase, TestCase
+from django.test import LiveServerTestCase
 from django.utils import unittest
 
 from .. import POT_DIRPATH
-
-from centralserver.i18n.management.commands.update_language_packs import convert_aws_urls_to_localhost_urls
-
-class UrlConversionTestCase(TestCase):
-
-    def test_poentry_urls_converted(self):
-        """ poentry urls should be converted from aws urls to localhost urls """
-        poentry = MagicMock(autospec=polib.POEntry)
-        poentry.msgid = "I love https://something.aws.org/cat_picture.jpg"
-        poentry.msgstr = "Ich liebe https://something.aws.org/cat_picture.jpg"
-
-        poentry = convert_aws_urls_to_localhost_urls(poentry)
-
-        converted_url = "/content/khan/cat_picture.jpg"
-        self.assertIn(converted_url, poentry.msgid)
-        self.assertIn(converted_url, poentry.msgstr)
 
 class TranslationCommentTestCase(LiveServerTestCase):
     """


### PR DESCRIPTION
Some attributes of a mocked object needed to be specified.
It was causing a MagicMock to be used where a str or another type was expected.
Also moved the test so that it can be specified by label, since the i18n label
doesn't work as expected right now in the central server.