### PR TITLE
Add pagination on start page

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "ka-lite-submodule"]
 	path = ka-lite-submodule
 	url = https://github.com/learningequality/ka-lite.git
-        branch = central-master
+        branch = central-develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 install:
   - make assets
   - pip install -r ka-lite-submodule/requirements_test.txt
-  - pip install --upgrade selenium\<3  # Upgrade Selenium because we don't want to change the 0.16.x sub module
+  - pip install --upgrade selenium  # Upgrade Selenium because we don't want to change the 0.16.x sub module
 
 # See: https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 
 install:
 - make assets
-- pip install -r ka-lite-submodule/requirements_test.txt; popd
+- pip install -r ka-lite-submodule/requirements_test.txt
 
 script:
 - python centralserver/manage.py test ab_testing -v 2 --traceback

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ services:
   - docker
 
 env:
+  global:
   - MOZ_HEADLESS=1
+  - PATH="$PATH:/home/travis/bin"
 
 before_install:
   - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile
@@ -19,12 +21,18 @@ install:
   - make assets
   - pip install -r ka-lite-submodule/requirements_test.txt
   - pip install --upgrade selenium  # Upgrade Selenium because we don't want to change the 0.16.x sub module
+  - wget -O geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v0.10.0/geckodriver-v0.10.0-linux64.tar.gz
+  - gunzip -c geckodriver.tar.gz | tar xopf -
+  - chmod +x geckodriver
+  - mkdir -p /home/travis/bin
+  - mv geckodriver /home/travis/bin
 
 # See: https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give xvfb some time to start
+  - export PATH="$PATH:/home/ubuntu/bin"
 
 script:
   - python centralserver/manage.py test ab_testing -v 2 --traceback

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ python:
 services:
   - docker
 
+env:
+  - MOZ_HEADLESS=1
+
 before_install:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
@@ -18,6 +21,10 @@ install:
 - make assets
 - pip install -r ka-lite-submodule/requirements_test.txt
 - pip install --upgrade selenium\<3  # Upgrade Selenium because we don't want to change the 0.16.x sub module
+
+before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 
 script:
 - python centralserver/manage.py test ab_testing -v 2 --traceback

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 sudo: false
 
 python:
-- '2.7'
+  - '2.7'
 
 services:
   - docker
@@ -12,24 +12,24 @@ env:
   - MOZ_HEADLESS=1
 
 before_install:
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
-- /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile
-  --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
+  - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile
+    --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
 
 install:
-- make assets
-- pip install -r ka-lite-submodule/requirements_test.txt
-- pip install --upgrade selenium\<3  # Upgrade Selenium because we don't want to change the 0.16.x sub module
+  - make assets
+  - pip install -r ka-lite-submodule/requirements_test.txt
+  - pip install --upgrade selenium\<3  # Upgrade Selenium because we don't want to change the 0.16.x sub module
 
+# See: https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui
 before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
 
 script:
-- python centralserver/manage.py test ab_testing -v 2 --traceback
-- python centralserver/manage.py test central -v 2 --traceback
-- python centralserver/manage.py test contact -v 2 --traceback
-- python centralserver/manage.py test faq -v 2 --traceback
-- python centralserver/manage.py test i18n -v 2 --traceback
-- python centralserver/manage.py test registration -v 2 --traceback
+  - python centralserver/manage.py test ab_testing -v 2 --traceback
+  - python centralserver/manage.py test central -v 2 --traceback
+  - python centralserver/manage.py test contact -v 2 --traceback
+  - python centralserver/manage.py test faq -v 2 --traceback
+  - python centralserver/manage.py test i18n -v 2 --traceback
+  - python centralserver/manage.py test registration -v 2 --traceback

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
 install:
 - make assets
 - pip install -r ka-lite-submodule/requirements_test.txt
+- pip install --upgrade selenium\<3  # Upgrade Selenium because we don't want to change the 0.16.x sub module
 
 script:
 - python centralserver/manage.py test ab_testing -v 2 --traceback

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -60,9 +60,14 @@ CMD cd /docker/mnt \
     && npm install \
     && ../make_assets_kalite.sh \
     && cd .. \
+# Commented out and replaced with a system-wide install further up, since grunt command wasn't in the path with this method
 #    && npm install grunt-cli \
     && cd centralserver \
-    && python manage.py setup --no-assessment-items --noinput \
+    # Add syncdb and migratedb because setup script fails to do so on 0.16.x
+    # for the central server
+    && python manage.py syncdb --noinput \
+    && python manage.py migrate \
+    && python manage.py setup --no-assessment-items --noinput --traceback \
     && grunt \
     && cd .. \
     && cd ka-lite-submodule \

--- a/centralserver/build.js
+++ b/centralserver/build.js
@@ -1,0 +1,1 @@
+../ka-lite-submodule/build.js

--- a/centralserver/central/templates/central/base.html
+++ b/centralserver/central/templates/central/base.html
@@ -163,10 +163,11 @@
           <div id="content-container" class="container content content-padding" role="main">
 
 
-                    {% block precontent %}
-                        {% include "distributed/partials/_messages.html" %}
-                    {% endblock precontent %}
-                    {% block content %}{% endblock content %}
+            {% block precontent %}
+                {% include "distributed/partials/_messages.html" %}
+            {% endblock precontent %}
+
+            {% block content %}{% endblock content %}
 
               <footer class="row-fluid"> <!-- copyright footer -->
                   <div class="span12 float-right">

--- a/centralserver/central/templates/central/base.html
+++ b/centralserver/central/templates/central/base.html
@@ -173,7 +173,7 @@
                   {% block attribution %}
                       <p></p>
                       <p>
-                          &copy; 2016 <a href="//learningequality.org/">Learning Equality</a>
+                          &copy; {% now "Y" %} <a href="//learningequality.org/">Learning Equality</a>
                       </p>
                       <p>
                           Except where otherwise noted, content on this site is licensed under a<br/>

--- a/centralserver/central/templates/central/org_management.html
+++ b/centralserver/central/templates/central/org_management.html
@@ -128,6 +128,15 @@
                         </tr>
                         {% endfor %}
                     </table>
+                    {% if zones_paginator.count > 1 %}
+                    <form method="GET">
+                        Page: <select name="zones_page" onchange="this.form.submit()">
+                            {% for page in zones_paginator.page_range %}
+                            <option value="{{ page }}"{% if zones_page == page %} selected{% endif %}>{{ page }}</option>
+                            {% endfor %}
+                        </select>
+                    </form>
+                    {% endif %}
                     {% if org.name != HEADLESS_ORG_NAME %}
                     <form method="link" action="{% url 'zone_add_to_org' org_id=org.id zone_id='new' %}">
                         <input class="button--small" type="submit" value="Create a new sharing network">

--- a/centralserver/kalite
+++ b/centralserver/kalite
@@ -1,0 +1,1 @@
+../ka-lite-submodule/kalite


### PR DESCRIPTION
New features on the central server :tada: 

* Adds pagination on start page (because there are a LOT of unaffiliated sharing networks)
* Uses current year in the footer
* Docker asset building now working in Travis
* Travis close to working, although Selenium is now too new for ab_tests to work
* Updates ka-lite-submodule to point to `central-develop`'s latest commit
* ...and that commit has the latest 0.16.x branch merged in

![image](https://user-images.githubusercontent.com/374612/60680436-94774d00-9e8b-11e9-9bd3-affe63620288.png)
