### PR TITLE
Add a 500 test page + remove requests dependency

### DIFF
--- a/centralserver/central/urls.py
+++ b/centralserver/central/urls.py
@@ -55,6 +55,7 @@ urlpatterns += patterns('',
 )
 
 urlpatterns += patterns(__package__ + '.views',
+    url(r'^test/500/$', 'handler_500', {}, 'test500'),  # Test for error handling
     url(r'^$', 'homepage', {}, 'homepage'),
     url(r'^content/(?P<page>\w+)/', 'content_page', {}, 'content_page'), # Example of a new landing page
 

--- a/centralserver/central/views.py
+++ b/centralserver/central/views.py
@@ -253,5 +253,6 @@ def handler_403(request, *args, **kwargs):
 def handler_404(request):
     return HttpResponseNotFound(render_to_string("central/404.html", {}, context_instance=RequestContext(request)))
 
+
 def handler_500(request):
     return HttpResponseServerError(render_to_string("central/500.html", {}, context_instance=RequestContext(request)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ argparse==1.2.1
 mock==1.0.1
 pathlib==1.0
 pygeoip==0.3.2
-requests==2.5.1
 responses==0.3.0
 simplekml==1.2.3
 six==1.9.0


### PR DESCRIPTION
`requests` dependency is already derived from KA Lite and has a version conflict