### PR TITLE
Update .wsgi to be a normal Python module

### DIFF
--- a/centralserver/wsgi.py
+++ b/centralserver/wsgi.py
@@ -1,15 +1,18 @@
-import os, sys, warnings
+import os
+import sys
+import warnings
+import kalite
 
 warnings.filterwarnings('ignore', message=r'Module .*? is being added to sys\.path', append=True)
 
 PROJECT_PATH = os.path.dirname(os.path.realpath(__file__))
 
+# Dynamically add bundled KA Lite packages to the path
 sys.path = [
-    os.path.join(PROJECT_PATH, "../"),
-    os.path.join(PROJECT_PATH, "../centralserver"),
+    os.path.join(os.path.dirname(kalite.__file__), 'packages', 'bundled'),
+    os.path.join(os.path.dirname(kalite.__file__), 'packages', 'dist'),
 ] + sys.path
 
 from django.core.handlers.wsgi import WSGIHandler
 
-os.environ['DJANGO_SETTINGS_MODULE'] = 'centralserver.settings'
 application = WSGIHandler()


### PR DESCRIPTION
Dynamically detect KA Lite from current Python environment

Will deploy to fix the staging server...