### PR TITLE
Do not pin six, it's part of ka-lite requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ simplekml==1.2.3
 wsgiref==0.1.2
 MySQL-python==1.2.5
 django-postmark==0.1.6
-ka-lite==0.17.6b4
+ka-lite==0.17.6b5

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ pathlib==1.0
 pygeoip==0.3.2
 responses==0.3.0
 simplekml==1.2.3
-six==1.9.0
 wsgiref==0.1.2
 MySQL-python==1.2.5
 django-postmark==0.1.6


### PR DESCRIPTION
Still need to figure out:

    ERROR: ka-lite 0.17.6b4 has requirement requests==2.11.1, but you'll have requests 2.22.0 which is incompatible.