### PR TITLE
When deleting users, don't CASCADE to Organization

### DIFF
--- a/centralserver/central/models.py
+++ b/centralserver/central/models.py
@@ -42,7 +42,7 @@ class Organization(ExtendedModel):
     country = models.CharField(max_length=100, blank=True)
     users = models.ManyToManyField(User)
     zones = models.ManyToManyField(Zone)
-    owner = models.ForeignKey(User, related_name="owned_organizations", null=True)
+    owner = models.ForeignKey(User, related_name="owned_organizations", null=True, on_delete=models.SET_NULL)
 
     HEADLESS_ORG_NAME = "Unclaimed Networks"
     HEADLESS_ORG_PK = None  # keep the primary key of the headless org around, for efficiency

--- a/centralserver/registration/management/commands/cleanupregistration.py
+++ b/centralserver/registration/management/commands/cleanupregistration.py
@@ -56,7 +56,7 @@ class Command(NoArgsCommand):
 
         """
         total_deleted = 0
-        for profile in RegistrationProfile.objects.all():
+        for profile in RegistrationProfile.objects.all().select_related("profile", "profile__user"):
             if profile.activation_key_expired():
                 user = profile.user
                 if not user.is_active:


### PR DESCRIPTION
Django 1.5 had CASCADE as an implicit default. This makes cleaning up inactive user accounts a bit risky, in case there is an irregularity in data.