### PR TITLE
Fix unreferenced "org"

### DIFF
--- a/centralserver/central/views.py
+++ b/centralserver/central/views.py
@@ -66,7 +66,9 @@ def org_management(request, org_id=None):
 
     zones = {}
     
-    zones_qs = org.get_zones()
+    zones_qs = Zone.objects.filter(
+        organization__pk__in=[org.pk for org in organizations.values()]
+    ).order_by("name")
     zones_paginator = Paginator(zones_qs, 20)
     
     page_query = request.GET.get("zones_page", "1")


### PR DESCRIPTION
This has affected the main Dashboard in an unfortunate way for people who didn't have sharing zones, as I understand it.

`org` should be left referenced in the first loop, but we ran into the below exception, I presume when the first `for` loop was empty.

```

  File "./centralserver/central/views.py", line 69, in org_management
    zones_qs = org.get_zones()

UnboundLocalError: local variable 'org' referenced before assignment
```