### PR TITLE
Register unsubscriptions / bounces

### DIFF
--- a/centralserver/registration/management/commands/email_registered_users.py
+++ b/centralserver/registration/management/commands/email_registered_users.py
@@ -133,6 +133,7 @@ class Command(BaseCommand):
                 ).update(
                     unsubscribe_decomissioning_emails=True
                 )
+                print("Email previously unsubscribed/bounced: {}".format(email))
             except:
                 print("Failed sending to: {}".format(receiver_list[0]))
                 raise

--- a/centralserver/registration/management/commands/email_registered_users.py
+++ b/centralserver/registration/management/commands/email_registered_users.py
@@ -13,6 +13,7 @@ from django import template
 from django.template.base import TemplateDoesNotExist
 from django.template.context import Context
 from django.contrib.auth.models import User
+from postmark.backends import PostmarkMailUnprocessableEntityException
 
 
 class Command(BaseCommand):
@@ -78,7 +79,8 @@ class Command(BaseCommand):
             raise CommandError("Use the file name of something in registration/emails/")
         
         registrations = RegistrationProfile.objects.filter(
-            activation_key=RegistrationProfile.ACTIVATED
+            activation_key=RegistrationProfile.ACTIVATED,
+            unsubscribe_decomissioning_emails=False,
         ).exclude(
             user__email=None
         ).order_by(
@@ -125,6 +127,12 @@ class Command(BaseCommand):
             try:
                 email1.send(fail_silently=False)
                 email_log.write("{}\n".format(email))
+            except PostmarkMailUnprocessableEntityException:
+                RegistrationProfile.objects.filter(
+                    user__email__iexact=email
+                ).update(
+                    unsubscribe_decomissioning_emails=True
+                )
             except:
                 print("Failed sending to: {}".format(receiver_list[0]))
                 raise

--- a/centralserver/registration/migrations/0002_auto__chg_field_user_username.py
+++ b/centralserver/registration/migrations/0002_auto__chg_field_user_username.py
@@ -1,3 +1,7 @@
+# THIS MIGRATION MIGRATES A COMPLETELY DIFFERENT APP!!!
+# WHY???
+# THIS IS SO MEAN!!
+
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/centralserver/registration/migrations/0003_auto__add_field_registrationprofile_unsubscribe_decomissioning_emails.py
+++ b/centralserver/registration/migrations/0003_auto__add_field_registrationprofile_unsubscribe_decomissioning_emails.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'RegistrationProfile.unsubscribe_decomissioning_emails'
+        db.add_column(u'registration_registrationprofile', 'unsubscribe_decomissioning_emails',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'RegistrationProfile.unsubscribe_decomissioning_emails'
+        db.delete_column(u'registration_registrationprofile', 'unsubscribe_decomissioning_emails')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '75'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'registration.registrationprofile': {
+            'Meta': {'object_name': 'RegistrationProfile'},
+            'activation_key': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'unsubscribe_decomissioning_emails': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'unique': 'True'})
+        }
+    }
+
+    complete_apps = ['registration']

--- a/centralserver/registration/models.py
+++ b/centralserver/registration/models.py
@@ -122,6 +122,8 @@ class RegistrationProfile(models.Model):
     user = models.ForeignKey(User, unique=True, verbose_name=_('user'))
     activation_key = models.CharField(_('activation key'), max_length=40)
 
+    unsubscribe_decomissioning_emails = models.BooleanField(default=False)
+
     objects = RegistrationManager()
 
     class Meta:

--- a/centralserver/registration/templates/registration/emails/export_shutdown2.txt
+++ b/centralserver/registration/templates/registration/emails/export_shutdown2.txt
@@ -67,7 +67,8 @@ learners in the long-run. If you have any questions, we encourage you to
 post in the relevant discussion pages on our Community Forum about
 KA Lite and/or Kolibri:
 
- - Community Forums: https://community.learningequality.org/
+ - Community Forum:
+   https://community.learningequality.org/
 
 
 With our warmest regards,


### PR DESCRIPTION
Fix for when Postmark reports:

```
You tried to send to a recipient that has been marked as inactive.
Found inactive addresses: x@example.com.
Inactive recipients are ones that have generated a hard bounce, a spam complaint, or a manual suppression.
```

See: https://postmarkapp.com/developer/api/overview#error-codes